### PR TITLE
Use SPV verification in get_transaction

### DIFF
--- a/daemons/bch.py
+++ b/daemons/bch.py
@@ -1,5 +1,5 @@
 from btc import BTCDaemon
-from utils import rpc
+from utils import get_exception_message, rpc
 
 
 class BCHDaemon(BTCDaemon):
@@ -60,6 +60,9 @@ class BCHDaemon(BTCDaemon):
 
     def get_status_str(self, status):
         return self.electrum.paymentrequest.pr_tooltips[status]
+
+    def get_exception_message(self, e):
+        return get_exception_message(e)
 
     @rpc
     async def get_transaction(self, tx, wallet=None):

--- a/daemons/spec/btc.json
+++ b/daemons/spec/btc.json
@@ -5,6 +5,7 @@
         "should be a transaction hash": -32001,
         "No such mempool or blockchain transaction. Use gettransaction for wallet transactions.": -32002,
         "No such mempool transaction.": -32002,
+        "missing transaction": -32002,
         "Request not found": -32003,
         "Invalid Bitcoin address or alias": -32004,
         "Invalid bitcoin address:": -32004,

--- a/daemons/utils.py
+++ b/daemons/utils.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import traceback
 from base64 import b64decode
 from dataclasses import dataclass
 from decimal import Decimal
@@ -88,6 +89,10 @@ def parse_params(params):
         kwargs = params
         args = ()
     return args, kwargs
+
+
+def get_exception_message(e):
+    return traceback.format_exception_only(type(e), e)[-1].strip()
 
 
 @dataclass


### PR DESCRIPTION
Also fixes issue on some servers raising verbose transactions unsupported

For now we wait for electrum protocol 1.5 to port this back to electrum and make it fast. This is added mostly to remove frequent CI failures in our SDK. Current SPV implementation is fine but it fetches full address history, protocol 1.5 is required to make this efficient. See https://github.com/spesmilo/electrum/issues/7342#issuecomment-877631266 and https://github.com/spesmilo/electrumx/pull/90

<strike>TODO:
- [x] Verify implementation or port to electrum, see https://github.com/spesmilo/electrum/issues/7342#issuecomment-877631266 (probably the latter, because bhi_lock might hang the whole daemon)
- [ ] Do the same for bch-based coins
- [ ] Improve error messages in verify_transaction
- [ ] Add ability to disable confirmations fetching/SPV verification
</strike>