### PR TITLE
Use aioredis 2.0

### DIFF
--- a/api/events.py
+++ b/api/events.py
@@ -58,13 +58,12 @@ async def send_message(message):
 
 
 async def listen(channel, custom_event_handler=None):  # pragma: no cover
-    while await channel.wait_message():
-        msg = await channel.get_json()
-        asyncio.ensure_future(process_message(msg, custom_event_handler))
+    async for message in utils.redis.listen_channel(channel):
+        asyncio.ensure_future(process_message(message, custom_event_handler))
 
 
 async def start_listening(custom_event_handler=None):  # pragma: no cover
-    _, channel = await utils.redis.make_subscriber(constants.EVENTS_CHANNEL)
+    channel = await utils.redis.make_subscriber(constants.EVENTS_CHANNEL)
     await listen(channel, custom_event_handler)
 
 

--- a/api/ext/tor.py
+++ b/api/ext/tor.py
@@ -109,9 +109,9 @@ async def refresh(log=True):  # pragma: no cover: used in production only
         onion_host = services_dict.get("BitcartCC Merchants API", "")
         if onion_host:
             onion_host = onion_host["hostname"] or ""
-        await settings.redis_pool.hmset_dict(
+        await settings.redis_pool.hset(
             REDIS_KEY,
-            {
+            mapping={
                 "onion_host": onion_host,
                 "services_dict": json.dumps(services_dict),
                 "anonymous_services_dict": json.dumps(anonymous_services_dict),
@@ -120,6 +120,6 @@ async def refresh(log=True):  # pragma: no cover: used in production only
 
 
 async def get_data(key, default=None, json_decode=False):
-    data = await settings.redis_pool.hget(REDIS_KEY, key, encoding="utf-8")
+    data = await settings.redis_pool.hget(REDIS_KEY, key)
     data = json.loads(data) if json_decode and data else data
     return data if data else default

--- a/api/settings.py
+++ b/api/settings.py
@@ -157,7 +157,8 @@ redis_pool = None
 
 async def init_redis():
     global redis_pool
-    redis_pool = await aioredis.create_redis_pool(REDIS_HOST)
+    redis_pool = aioredis.from_url(REDIS_HOST, decode_responses=True)
+    await redis_pool.ping()
 
 
 async def init_db():

--- a/requirements/deterministic/web.txt
+++ b/requirements/deterministic/web.txt
@@ -49,9 +49,9 @@ aiohttp==3.7.4.post0 \
     # via
     #   bitcart
     #   jsonrpcclient
-aioredis==1.3.1 \
-    --hash=sha256:15f8af30b044c771aee6787e5ec24694c048184c7b9e54c3b60c750a4b93273a \
-    --hash=sha256:b61808d7e97b7cd5a92ed574937a079c9387fdadd22bfbfa7ad2fd319ecc26e3
+aioredis==2.0.0 \
+    --hash=sha256:3a2de4b614e6a5f8e104238924294dc4e811aefbe17ddf52c04a93cbf06e67db \
+    --hash=sha256:9921d68a3df5c5cdb0d5b49ad4fc88a4cfdd60c108325df4f0066e8410c55ffb
     # via -r requirements/web.txt
 alembic==1.5.8 \
     --hash=sha256:8a259f0a4c8b350b03579d77ce9e810b19c65bf0af05f84efb69af13ad50801e \
@@ -246,7 +246,7 @@ hiredis==2.0.0 \
     --hash=sha256:e3447d9e074abf0e3cd85aef8131e01ab93f9f0e86654db7ac8a3f73c63706ce \
     --hash=sha256:f52010e0a44e3d8530437e7da38d11fb822acfb0d5b12e9cd5ba655509937ca0 \
     --hash=sha256:f8196f739092a78e4f6b1b2172679ed3343c39c61a3e9d722ce6fcf1dac2824a
-    # via aioredis
+    # via -r requirements/web.txt
 httptools==0.1.1 \
     --hash=sha256:0a4b1b2012b28e68306575ad14ad5e9120b34fccd02a81eb08838d7e3bbb48be \
     --hash=sha256:3592e854424ec94bd17dc3e0c96a64e459ec4147e6d53c0a42d0ebcef9cb9c5d \
@@ -630,6 +630,7 @@ typing-extensions==3.7.4.3 \
     --hash=sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f
     # via
     #   aiohttp
+    #   aioredis
     #   asyncpg
     #   pydantic
     #   uvicorn

--- a/requirements/web.txt
+++ b/requirements/web.txt
@@ -1,11 +1,12 @@
 -r base.txt
 aiofiles
-aioredis<2.0 # TODO: upgrade after a few bugfix releases
+aioredis
 alembic
 bitcart
 email-validator
 fastapi
 gino
+hiredis
 Jinja2
 msgpack
 notifiers


### PR DESCRIPTION
After doing the migration in opsdroid, we can do the same.
I switched some commands to the new api, now it is all more stable because it follows well-tested redis-py design
