### PR TITLE
Add python 3.10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,7 @@ workflows:
                 - "3.7"
                 - "3.8"
                 - "3.9"
+                - "3.10"
       - bitcartcc/functional-tests:
           name: functional-tests
           executor: main-executor

--- a/api/logger.py
+++ b/api/logger.py
@@ -13,7 +13,7 @@ from api.settings import LOG_FILE, LOGSERVER_HOST
 
 
 def get_exception_message(exc: Exception):
-    return "\n" + "".join(traceback.format_exception(etype=type(exc), value=exc, tb=exc.__traceback__))
+    return "\n" + "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
 
 def timed_log_namer(default_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ filterwarnings = [
     "error::DeprecationWarning",
     "error::PendingDeprecationWarning",
     "ignore:.*distutils package is deprecated.*:DeprecationWarning:aioredis", # TODO: remove when aioredis fixes this
-    "ignore:There is no current event loop:DeprecationWarning:asyncio"
+    "ignore:There is no current event loop:DeprecationWarning"
 ]
 norecursedirs = ["tests/functional"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ addopts = [
 ]
 filterwarnings = [
     "error::DeprecationWarning",
-    "error::PendingDeprecationWarning"
+    "error::PendingDeprecationWarning",
+    "ignore:.*distutils package is deprecated.*:DeprecationWarning:aioredis" # TODO: remove when aioredis fixes this
 ]
 norecursedirs = ["tests/functional"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ addopts = [
 filterwarnings = [
     "error::DeprecationWarning",
     "error::PendingDeprecationWarning",
-    "ignore:.*distutils package is deprecated.*:DeprecationWarning:aioredis" # TODO: remove when aioredis fixes this
+    "ignore:.*distutils package is deprecated.*:DeprecationWarning:aioredis", # TODO: remove when aioredis fixes this
+    "ignore:There is no current event loop:DeprecationWarning:asyncio"
 ]
 norecursedirs = ["tests/functional"]
 

--- a/tests/test_views/test_views.py
+++ b/tests/test_views/test_views.py
@@ -1,7 +1,7 @@
 import asyncio
 import json as json_module
 import os
-import platform
+import sys
 from decimal import Decimal
 
 import pytest
@@ -32,8 +32,7 @@ def is_event_loop_running():
 def get_future_return_value(return_val):
     future = asyncio.Future()
     future.set_result(return_val)
-    minor_ver = int(platform.python_version_tuple()[1])
-    return future if minor_ver < 8 or is_event_loop_running() else return_val
+    return future if sys.version_info < (3, 8) or is_event_loop_running() else return_val
 
 
 def test_docs_root(client: TestClient):


### PR DESCRIPTION
This works, but our event loop handling should be refactored first, see #247 
This only adds basic 3.10 support with some warning ignores.
The next PR will try to upgrade fastapi and starlette to use anyio
Also aiohttp doesn't work with 3.10 yet, but it will fix itself when aiohttp gets upgraded, 3.10 won't be a base version for us for a while anyway
```
Traceback (most recent call last):
  File "/mnt/D/github/bitcart/daemons/ltc.py", line 16, in <module>
    daemon.start()
  File "/mnt/D/github/bitcart/daemons/base.py", line 114, in start
    web.run_app(self.app, host=self.HOST, port=self.PORT)
  File "/home/alex/envs/bitcart-310/lib/python3.10/site-packages/aiohttp/web.py", line 512, in run_app
    _cancel_tasks({main_task}, loop)
  File "/home/alex/envs/bitcart-310/lib/python3.10/site-packages/aiohttp/web.py", line 444, in _cancel_tasks
    asyncio.gather(*to_cancel, loop=loop, return_exceptions=True)
TypeError: gather() got an unexpected keyword argument 'loop'
```