### PR TITLE
Upgrade electrum to 4.1.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
 
       - restore_cache:
           keys:
-            - v1-lint-dependencies-{{ .Branch }}-{{ checksum "~/.pyenv/version" }}-{{ checksum "requirements/lint.txt" }}
+            - v1-lint-dependencies-{{ .Branch }}-{{ checksum "~/.pyenv/version" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/lint.txt" }}
 
       - run:
           name: Install dependencies
@@ -63,7 +63,7 @@ commands:
       - save_cache:
           paths:
             - ~/venv
-          key: v1-lint-dependencies-{{ .Branch }}-{{ checksum "~/.pyenv/version" }}-{{ checksum "requirements/lint.txt" }}
+          key: v1-lint-dependencies-{{ .Branch }}-{{ checksum "~/.pyenv/version" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/lint.txt" }}
 
   run-lint:
     steps:

--- a/daemons/btc.py
+++ b/daemons/btc.py
@@ -156,8 +156,8 @@ class BTCDaemon(BaseDaemon):
         self.fx = self.daemon.fx
 
     async def shutdown_daemon(self):
-        if self.daemon and self.loop:
-            await self.loop.run_in_executor(None, self.daemon.on_stop)
+        if self.daemon:
+            await self.daemon.stop()
 
     async def on_shutdown(self, app):
         await self.shutdown_daemon()

--- a/requirements/daemons/bch.txt
+++ b/requirements/daemons/bch.txt
@@ -1,2 +1,2 @@
 aiohttp<4.0
-https://github.com/Electron-Cash/Electron-Cash/archive/a84848414d68225ddf09ea490b97954ce25604b9.zip
+https://github.com/Electron-Cash/Electron-Cash/archive/d5217ed3e878bd56977181f022f9e5c43f449241.zip

--- a/requirements/daemons/bsty.txt
+++ b/requirements/daemons/bsty.txt
@@ -1,1 +1,1 @@
-https://github.com/GlobalBoost/electrum/archive/f487baa864904df2591d43d5420fc01370955230.zip#egg=electrum-bsty[crypto]
+https://github.com/GlobalBoost/electrum/archive/413e7e5d684394312aabe9e15b233a1b86ee3be1.zip#egg=electrum-bsty[crypto]

--- a/requirements/daemons/btc.txt
+++ b/requirements/daemons/btc.txt
@@ -1,1 +1,1 @@
-https://github.com/spesmilo/electrum/archive/aafa74ed082edbc01d44bbf874a645c4a43c88aa.zip#egg=electrum[crypto]
+https://github.com/spesmilo/electrum/archive/a3e1d2e25e78231b30ff1103345095827a909d88.zip#egg=electrum[crypto]

--- a/requirements/daemons/ltc.txt
+++ b/requirements/daemons/ltc.txt
@@ -1,2 +1,2 @@
-https://github.com/pooler/electrum-ltc/archive/3e8d42fcb59f7139f3c3ec2d580b7790369e302a.zip#egg=electrum-ltc[crypto]
+https://github.com/pooler/electrum-ltc/archive/193400057a47f3953ab4ca4bd17034ce5933d527.zip#egg=electrum-ltc[crypto]
 scrypt>=0.6.0

--- a/requirements/daemons/xrg.txt
+++ b/requirements/daemons/xrg.txt
@@ -1,2 +1,2 @@
 aiohttp<4.0
-https://github.com/Ergon-moe/Oregano/archive/1b37bd01b25845bd31f37492d408813728030582.zip
+https://github.com/Ergon-moe/Oregano/archive/88c912d769b663660b70bfb04485d747f37588f5.zip

--- a/requirements/deterministic/daemons/bch.txt
+++ b/requirements/deterministic/daemons/bch.txt
@@ -106,16 +106,16 @@ charset-normalizer==2.0.10 \
     # via
     #   aiohttp
     #   requests
-dnspython==2.1.0 \
-    --hash=sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216 \
-    --hash=sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4
+dnspython==2.2.0 \
+    --hash=sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44 \
+    --hash=sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6
     # via electron-cash
 ecdsa==0.17.0 \
     --hash=sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676 \
     --hash=sha256:b9f500bb439e4153d0330610f5d26baaf18d17b8ced1bc54410d189385ea68aa
     # via electron-cash
-electron-cash @ https://github.com/Electron-Cash/Electron-Cash/archive/a84848414d68225ddf09ea490b97954ce25604b9.zip \
-    --hash=sha256:25703af5a814a800e2d1fefc2a5010fc25a5f7a8661d34353e86ba1c99f8b257
+electron-cash @ https://github.com/Electron-Cash/Electron-Cash/archive/d5217ed3e878bd56977181f022f9e5c43f449241.zip \
+    --hash=sha256:d951f6f80d4de41372193f715037e3038ee6ce8bd4bf0c01c847d1b723beded9
     # via -r requirements/daemons/bch.txt
 frozenlist==1.2.0 \
     --hash=sha256:01d79515ed5aa3d699b05f6bdcf1fe9087d61d6b53882aa599a10853f0479c6c \

--- a/requirements/deterministic/daemons/bsty.txt
+++ b/requirements/deterministic/daemons/bsty.txt
@@ -196,12 +196,12 @@ cryptography==36.0.1 \
     --hash=sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1 \
     --hash=sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee
     # via electrum-bsty
-dnspython==2.0.0 \
-    --hash=sha256:044af09374469c3a39eeea1a146e8cac27daec951f1f1f157b1962fc7cb9d1b7 \
-    --hash=sha256:40bb3c24b9d4ec12500f0124288a65df232a3aa749bb0c39734b782873a2544d
+dnspython==2.2.0 \
+    --hash=sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44 \
+    --hash=sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6
     # via electrum-bsty
-electrum-bsty @ https://github.com/GlobalBoost/electrum/archive/f487baa864904df2591d43d5420fc01370955230.zip \
-    --hash=sha256:13afcbb50bec22f7416f26268981e5e04808c51f56f785d98957e538ea68bb48
+electrum-bsty @ https://github.com/GlobalBoost/electrum/archive/413e7e5d684394312aabe9e15b233a1b86ee3be1.zip \
+    --hash=sha256:c447921f056ad54e3ba385d08fea515daf4c373942fed4281697090f773334a9
     # via -r requirements/daemons/bsty.txt
 frozenlist==1.2.0 \
     --hash=sha256:01d79515ed5aa3d699b05f6bdcf1fe9087d61d6b53882aa599a10853f0479c6c \

--- a/requirements/deterministic/daemons/btc.txt
+++ b/requirements/deterministic/daemons/btc.txt
@@ -196,12 +196,12 @@ cryptography==36.0.1 \
     --hash=sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1 \
     --hash=sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee
     # via electrum
-dnspython==2.0.0 \
-    --hash=sha256:044af09374469c3a39eeea1a146e8cac27daec951f1f1f157b1962fc7cb9d1b7 \
-    --hash=sha256:40bb3c24b9d4ec12500f0124288a65df232a3aa749bb0c39734b782873a2544d
+dnspython==2.2.0 \
+    --hash=sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44 \
+    --hash=sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6
     # via electrum
-electrum @ https://github.com/spesmilo/electrum/archive/aafa74ed082edbc01d44bbf874a645c4a43c88aa.zip \
-    --hash=sha256:f8ea37a0d6282c28105b64e8d8fe37c00539cab0162a1be28abf54fb6822da3a
+electrum @ https://github.com/spesmilo/electrum/archive/a3e1d2e25e78231b30ff1103345095827a909d88.zip \
+    --hash=sha256:20215d318420db6c54664d06c7c659c58ccbbc4a67805fa3759bef22f496e3b8
     # via -r requirements/daemons/btc.txt
 frozenlist==1.2.0 \
     --hash=sha256:01d79515ed5aa3d699b05f6bdcf1fe9087d61d6b53882aa599a10853f0479c6c \

--- a/requirements/deterministic/daemons/ltc.txt
+++ b/requirements/deterministic/daemons/ltc.txt
@@ -196,12 +196,12 @@ cryptography==36.0.1 \
     --hash=sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1 \
     --hash=sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee
     # via electrum-ltc
-dnspython==2.0.0 \
-    --hash=sha256:044af09374469c3a39eeea1a146e8cac27daec951f1f1f157b1962fc7cb9d1b7 \
-    --hash=sha256:40bb3c24b9d4ec12500f0124288a65df232a3aa749bb0c39734b782873a2544d
+dnspython==2.2.0 \
+    --hash=sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44 \
+    --hash=sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6
     # via electrum-ltc
-electrum-ltc @ https://github.com/pooler/electrum-ltc/archive/3e8d42fcb59f7139f3c3ec2d580b7790369e302a.zip \
-    --hash=sha256:c8f683f223c13bed582f01b721ceab54030cc81f7f4a6a95841c8943915513f6
+electrum-ltc @ https://github.com/pooler/electrum-ltc/archive/193400057a47f3953ab4ca4bd17034ce5933d527.zip \
+    --hash=sha256:9ac8a09b37d0801bb6919358a621603959b5ebb98210f8796b48c1df5b955188
     # via -r requirements/daemons/ltc.txt
 frozenlist==1.2.0 \
     --hash=sha256:01d79515ed5aa3d699b05f6bdcf1fe9087d61d6b53882aa599a10853f0479c6c \

--- a/requirements/deterministic/daemons/xrg.txt
+++ b/requirements/deterministic/daemons/xrg.txt
@@ -106,9 +106,9 @@ charset-normalizer==2.0.10 \
     # via
     #   aiohttp
     #   requests
-dnspython==2.1.0 \
-    --hash=sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216 \
-    --hash=sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4
+dnspython==2.2.0 \
+    --hash=sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44 \
+    --hash=sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6
     # via oregano
 ecdsa==0.17.0 \
     --hash=sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676 \
@@ -276,8 +276,8 @@ multidict==5.2.0 \
     # via
     #   aiohttp
     #   yarl
-oregano @ https://github.com/Ergon-moe/Oregano/archive/1b37bd01b25845bd31f37492d408813728030582.zip \
-    --hash=sha256:7c7ce8637279973e341cfc0422e013741d25d5a221afe15bfb87a9977288c274
+oregano @ https://github.com/Ergon-moe/Oregano/archive/88c912d769b663660b70bfb04485d747f37588f5.zip \
+    --hash=sha256:bfd5f4027539fac3f1fae5139450e78dd3879d2f1e4f163550befb5edc1a5069
     # via -r requirements/daemons/xrg.txt
 pathvalidate==2.5.0 \
     --hash=sha256:119ba36be7e9a405d704c7b7aea4b871c757c53c9adc0ed64f40be1ed8da2781 \

--- a/requirements/deterministic/web.txt
+++ b/requirements/deterministic/web.txt
@@ -257,9 +257,9 @@ cryptography==36.0.1 \
     --hash=sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1 \
     --hash=sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee
     # via paramiko
-dnspython==2.1.0 \
-    --hash=sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216 \
-    --hash=sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4
+dnspython==2.2.0 \
+    --hash=sha256:081649da27ced5e75709a1ee542136eaba9842a0fe4c03da4fb0a3d3ed1f3c44 \
+    --hash=sha256:e79351e032d0b606b98d38a4b0e6e2275b31a5b85c873e587cc11b73aca026d6
     # via email-validator
 email-validator==1.1.3 \
     --hash=sha256:5675c8ceb7106a37e40e2698a57c056756bf3f272cfa8682a4f87ebd95d8440b \


### PR DESCRIPTION
Notable changes:
- Graceful stopping
- Signet support (was added before)
- Free pin of dnspython and qdarkstyle dependencies (TODO: PR to electron cash unpinning qdarkstyle)