### PR TITLE
Update web.txt

### DIFF
--- a/requirements/web.txt
+++ b/requirements/web.txt
@@ -16,4 +16,5 @@ psycopg2-binary
 python-dateutil
 python-dotenv
 python-multipart
+sqlalchemy<1.4
 uvicorn[standard]


### PR DESCRIPTION
Gino does not work with sqlalchemy 1.4, throwing an error when running the alembic command. This allows the alembic command to run by forcing 1.3.
AttributeError: module 'sqlalchemy.sql.schema' has no attribute '_schema_getter'