### PR TITLE
Pyre type error fixed

### DIFF
--- a/api/schemes.py
+++ b/api/schemes.py
@@ -139,7 +139,7 @@ class Wallet(CreateWallet):
 class StoreCheckoutSettings(BaseModel):
     expiration: int = 15
     transaction_speed: int = 0
-    underpaid_percentage: Decimal = 0
+    underpaid_percentage: int = 0
     custom_logo_link: str = ""
     recommended_fee_target_blocks: int = 1
     show_recommended_fee: bool = True

--- a/api/schemes.py
+++ b/api/schemes.py
@@ -139,7 +139,7 @@ class Wallet(CreateWallet):
 class StoreCheckoutSettings(BaseModel):
     expiration: int = 15
     transaction_speed: int = 0
-    underpaid_percentage: int = 0
+    underpaid_percentage: Decimal = 0.0
     custom_logo_link: str = ""
     recommended_fee_target_blocks: int = 1
     show_recommended_fee: bool = True


### PR DESCRIPTION
**"filename"**: "api/schemes.py"
**"warning_type"**: "Incompatible attribute type [8]"
**"warning_message"**: " Attribute `underpaid_percentage` declared in class `StoreCheckoutSettings` has type `Decimal` but is used as type `int`."
**"warning_line"**: 142
**"fix"**: Decimal to int