### PR TITLE
Feature: Support Coingecko paid API

### DIFF
--- a/api/ext/exchanges/coingecko.py
+++ b/api/ext/exchanges/coingecko.py
@@ -57,7 +57,7 @@ class CoingeckoExchange(BaseExchange):
 
     async def refresh(self):
         vs_currencies = await fetch_delayed(
-            "GET", "https://{self.coins_api}/api/v3/simple/supported_vs_currencies", headers=self.headers
+            "GET", f"https://{self.coins_api}/api/v3/simple/supported_vs_currencies", headers=self.headers
         )
         if not self.coins_cache:
             self.coins_cache = await fetch_delayed(

--- a/api/ext/exchanges/coingecko.py
+++ b/api/ext/exchanges/coingecko.py
@@ -48,9 +48,9 @@ class CoingeckoExchange(BaseExchange):
     def __init__(self, coins, contracts):
         super().__init__(coins, contracts)
         self.coins_cache = {}
-        if settings.coingecko_apikey:
+        if settings.settings.coingecko_apikey:
             self.coins_api = "https://pro-api.coingecko.com" 
-            self.headers = {"x-cg-pro-api-key": settings.coingecko_apikey}
+            self.headers = {"x-cg-pro-api-key": settings.settings.coingecko_apikey}
         else:
             self.coins_api = "https://api.coingecko.com"
             self.headers = {}

--- a/api/ext/exchanges/coingecko.py
+++ b/api/ext/exchanges/coingecko.py
@@ -57,11 +57,11 @@ class CoingeckoExchange(BaseExchange):
 
     async def refresh(self):
         vs_currencies = await fetch_delayed(
-            "GET", "https://" + self.coins_api + "/api/v3/simple/supported_vs_currencies", headers=self.headers
+            "GET", "https://{self.coins_api}/api/v3/simple/supported_vs_currencies", headers=self.headers
         )
         if not self.coins_cache:
             self.coins_cache = await fetch_delayed(
-                "GET", "https://" + self.coins_api + "/api/v3/coins/list?include_platform=true", headers=self.headers
+                "GET", f"https://{self.coins_api}/api/v3/coins/list?include_platform=true", headers=self.headers
             )
         coins = []
         for coin in self.coins.copy():
@@ -75,7 +75,7 @@ class CoingeckoExchange(BaseExchange):
                     coins.append(currency["id"])
         data = await fetch_delayed(
             "GET",
-            f"https://" + self.coins_api + ".com/api/v3/simple/price?ids={','.join(coins)}"
+            f"https://{self.coins_api}.com/api/v3/simple/price?ids={','.join(coins)}"
             f"&vs_currencies={','.join(vs_currencies)}&precision=full",
             headers=self.headers,
         )
@@ -95,7 +95,7 @@ def coingecko_based_exchange(name):
         async def refresh(self):
             if not self.coins_cache:
                 self.coins_cache = await fetch_delayed(
-                    "GET", "https://" + self.coins_api + "/api/v3/coins/list", headers=self.headers
+                    "GET", f"https://{self.coins_api}/api/v3/coins/list", headers=self.headers
                 )
             coins = []
             for coin in self.coins.copy():
@@ -105,7 +105,7 @@ def coingecko_based_exchange(name):
             self.quotes = await self.fetch_rates(coins)
 
         async def fetch_rates(self, coins, page=1):
-            base_url = f"https://" + self.coins_api + "/api/v3/exchanges/{name}/tickers"
+            base_url = f"https://{self.coins_api}/api/v3/exchanges/{name}/tickers"
             resp, data = await fetch_delayed(
                 "GET", f"{base_url}?page={page}&coin_ids={','.join(coins)}", return_json=False, headers=self.headers
             )

--- a/api/ext/exchanges/coingecko.py
+++ b/api/ext/exchanges/coingecko.py
@@ -49,16 +49,20 @@ class CoingeckoExchange(BaseExchange):
         super().__init__(coins, contracts)
         self.coins_cache = {}
         if settings.settings.coingecko_apikey:
-            self.coins_api = "https://pro-api.coingecko.com" 
+            self.coins_api = "https://pro-api.coingecko.com"
             self.headers = {"x-cg-pro-api-key": settings.settings.coingecko_apikey}
         else:
             self.coins_api = "https://api.coingecko.com"
             self.headers = {}
 
     async def refresh(self):
-        vs_currencies = await fetch_delayed("GET", "https://"+self.coins_api+"/api/v3/simple/supported_vs_currencies", headers=self.headers)
+        vs_currencies = await fetch_delayed(
+            "GET", "https://" + self.coins_api + "/api/v3/simple/supported_vs_currencies", headers=self.headers
+        )
         if not self.coins_cache:
-            self.coins_cache = await fetch_delayed("GET", "https://"+self.coins_api+"/api/v3/coins/list?include_platform=true", headers=self.headers)
+            self.coins_cache = await fetch_delayed(
+                "GET", "https://" + self.coins_api + "/api/v3/coins/list?include_platform=true", headers=self.headers
+            )
         coins = []
         for coin in self.coins.copy():
             currency = find_by_coin(self.coins_cache, coin)
@@ -71,9 +75,9 @@ class CoingeckoExchange(BaseExchange):
                     coins.append(currency["id"])
         data = await fetch_delayed(
             "GET",
-            f"https://"+self.coins_api+".com/api/v3/simple/price?ids={','.join(coins)}"
+            f"https://" + self.coins_api + ".com/api/v3/simple/price?ids={','.join(coins)}"
             f"&vs_currencies={','.join(vs_currencies)}&precision=full",
-            headers=self.headers
+            headers=self.headers,
         )
         self.quotes = {
             f"{find_id(self.coins_cache, k).upper()}_{k2.upper()}": utils.common.precise_decimal(v2)
@@ -90,7 +94,9 @@ def coingecko_based_exchange(name):
 
         async def refresh(self):
             if not self.coins_cache:
-                self.coins_cache = await fetch_delayed("GET", "https://"+self.coins_api+"/api/v3/coins/list", headers=self.headers)
+                self.coins_cache = await fetch_delayed(
+                    "GET", "https://" + self.coins_api + "/api/v3/coins/list", headers=self.headers
+                )
             coins = []
             for coin in self.coins.copy():
                 currency = find_by_coin(self.coins_cache, coin)
@@ -99,8 +105,10 @@ def coingecko_based_exchange(name):
             self.quotes = await self.fetch_rates(coins)
 
         async def fetch_rates(self, coins, page=1):
-            base_url = f"https://"+self.coins_api+"/api/v3/exchanges/{name}/tickers"
-            resp, data = await fetch_delayed("GET", f"{base_url}?page={page}&coin_ids={','.join(coins)}", return_json=False, headers=self.headers)
+            base_url = f"https://" + self.coins_api + "/api/v3/exchanges/{name}/tickers"
+            resp, data = await fetch_delayed(
+                "GET", f"{base_url}?page={page}&coin_ids={','.join(coins)}", return_json=False, headers=self.headers
+            )
             result = {f"{x['base']}_{x['target']}": utils.common.precise_decimal(x["last"]) for x in data["tickers"]}
             total = resp.headers.get("total")
             per_page = resp.headers.get("per-page")

--- a/api/ext/exchanges/coingecko.py
+++ b/api/ext/exchanges/coingecko.py
@@ -49,10 +49,10 @@ class CoingeckoExchange(BaseExchange):
         super().__init__(coins, contracts)
         self.coins_cache = {}
         if settings.settings.coingecko_apikey:
-            self.coins_api = "https://pro-api.coingecko.com"
+            self.coins_api = "pro-api.coingecko.com"
             self.headers = {"x-cg-pro-api-key": settings.settings.coingecko_apikey}
         else:
-            self.coins_api = "https://api.coingecko.com"
+            self.coins_api = "api.coingecko.com"
             self.headers = {}
 
     async def refresh(self):
@@ -75,7 +75,7 @@ class CoingeckoExchange(BaseExchange):
                     coins.append(currency["id"])
         data = await fetch_delayed(
             "GET",
-            f"https://{self.coins_api}.com/api/v3/simple/price?ids={','.join(coins)}"
+            f"https://{self.coins_api}/api/v3/simple/price?ids={','.join(coins)}"
             f"&vs_currencies={','.join(vs_currencies)}&precision=full",
             headers=self.headers,
         )

--- a/api/ext/exchanges/coingecko.py
+++ b/api/ext/exchanges/coingecko.py
@@ -6,7 +6,7 @@ from api.ext.exchanges.base import BaseExchange
 
 
 async def fetch_delayed(*args, delay=1, **kwargs):
-    resp, data = await utils.common.send_request(*args, return_json=False)
+    resp, data = await utils.common.send_request(*args, return_json=False, **kwargs)
     if resp.status == 429:
         if delay < 60:
             await asyncio.sleep(delay)
@@ -48,11 +48,17 @@ class CoingeckoExchange(BaseExchange):
     def __init__(self, coins, contracts):
         super().__init__(coins, contracts)
         self.coins_cache = {}
+        if settings.coingecko_apikey:
+            self.coins_api = "https://pro-api.coingecko.com" 
+            self.headers = {"x-cg-pro-api-key": settings.coingecko_apikey}
+        else:
+            self.coins_api = "https://api.coingecko.com"
+            self.headers = {}
 
     async def refresh(self):
-        vs_currencies = await fetch_delayed("GET", "https://api.coingecko.com/api/v3/simple/supported_vs_currencies")
+        vs_currencies = await fetch_delayed("GET", "https://"+self.coins_api+"/api/v3/simple/supported_vs_currencies", headers=self.headers)
         if not self.coins_cache:
-            self.coins_cache = await fetch_delayed("GET", "https://api.coingecko.com/api/v3/coins/list?include_platform=true")
+            self.coins_cache = await fetch_delayed("GET", "https://"+self.coins_api+"/api/v3/coins/list?include_platform=true", headers=self.headers)
         coins = []
         for coin in self.coins.copy():
             currency = find_by_coin(self.coins_cache, coin)
@@ -65,8 +71,9 @@ class CoingeckoExchange(BaseExchange):
                     coins.append(currency["id"])
         data = await fetch_delayed(
             "GET",
-            f"https://api.coingecko.com/api/v3/simple/price?ids={','.join(coins)}"
+            f"https://"+self.coins_api+".com/api/v3/simple/price?ids={','.join(coins)}"
             f"&vs_currencies={','.join(vs_currencies)}&precision=full",
+            headers=self.headers
         )
         self.quotes = {
             f"{find_id(self.coins_cache, k).upper()}_{k2.upper()}": utils.common.precise_decimal(v2)
@@ -83,7 +90,7 @@ def coingecko_based_exchange(name):
 
         async def refresh(self):
             if not self.coins_cache:
-                self.coins_cache = await fetch_delayed("GET", "https://api.coingecko.com/api/v3/coins/list")
+                self.coins_cache = await fetch_delayed("GET", "https://"+self.coins_api+"/api/v3/coins/list", headers=self.headers)
             coins = []
             for coin in self.coins.copy():
                 currency = find_by_coin(self.coins_cache, coin)
@@ -92,8 +99,8 @@ def coingecko_based_exchange(name):
             self.quotes = await self.fetch_rates(coins)
 
         async def fetch_rates(self, coins, page=1):
-            base_url = f"https://api.coingecko.com/api/v3/exchanges/{name}/tickers"
-            resp, data = await fetch_delayed("GET", f"{base_url}?page={page}&coin_ids={','.join(coins)}", return_json=False)
+            base_url = f"https://"+self.coins_api+"/api/v3/exchanges/{name}/tickers"
+            resp, data = await fetch_delayed("GET", f"{base_url}?page={page}&coin_ids={','.join(coins)}", return_json=False, headers=self.headers)
             result = {f"{x['base']}_{x['target']}": utils.common.precise_decimal(x["last"]) for x in data["tickers"]}
             total = resp.headers.get("total")
             per_page = resp.headers.get("per-page")

--- a/api/ext/exchanges/rates_manager.py
+++ b/api/ext/exchanges/rates_manager.py
@@ -81,8 +81,8 @@ class RatesManager:
         for name, exchange_cls in self._exchange_classes.items():
             self.exchanges[name] = exchange_cls(coins, final_contracts)
         try:
-            if settings.coingecko_apikey:
-                coingecko_exchanges = await utils.common.send_request("GET", "https://pro-api.coingecko.com/api/v3/exchanges/list", headers={"x-cg-pro-api-key": settings.coingecko_apikey})
+            if settings.settings.coingecko_apikey:
+                coingecko_exchanges = await utils.common.send_request("GET", "https://pro-api.coingecko.com/api/v3/exchanges/list", headers={"x-cg-pro-api-key": settings.settings.coingecko_apikey})
             else:
                 coingecko_exchanges = await utils.common.send_request("GET", "https://api.coingecko.com/api/v3/exchanges/list")
             for exchange in coingecko_exchanges:

--- a/api/ext/exchanges/rates_manager.py
+++ b/api/ext/exchanges/rates_manager.py
@@ -82,7 +82,11 @@ class RatesManager:
             self.exchanges[name] = exchange_cls(coins, final_contracts)
         try:
             if settings.settings.coingecko_apikey:
-                coingecko_exchanges = await utils.common.send_request("GET", "https://pro-api.coingecko.com/api/v3/exchanges/list", headers={"x-cg-pro-api-key": settings.settings.coingecko_apikey})
+                coingecko_exchanges = await utils.common.send_request(
+                    "GET",
+                    "https://pro-api.coingecko.com/api/v3/exchanges/list",
+                    headers={"x-cg-pro-api-key": settings.settings.coingecko_apikey},
+                )
             else:
                 coingecko_exchanges = await utils.common.send_request("GET", "https://api.coingecko.com/api/v3/exchanges/list")
             for exchange in coingecko_exchanges:

--- a/api/ext/exchanges/rates_manager.py
+++ b/api/ext/exchanges/rates_manager.py
@@ -81,7 +81,10 @@ class RatesManager:
         for name, exchange_cls in self._exchange_classes.items():
             self.exchanges[name] = exchange_cls(coins, final_contracts)
         try:
-            coingecko_exchanges = await utils.common.send_request("GET", "https://api.coingecko.com/api/v3/exchanges/list")
+            if settings.coingecko_apikey:
+                coingecko_exchanges = await utils.common.send_request("GET", "https://pro-api.coingecko.com/api/v3/exchanges/list", headers={"x-cg-pro-api-key": settings.coingecko_apikey})
+            else:
+                coingecko_exchanges = await utils.common.send_request("GET", "https://api.coingecko.com/api/v3/exchanges/list")
             for exchange in coingecko_exchanges:
                 if exchange["id"] not in self.exchanges:
                     self.exchanges[exchange["id"]] = coingecko_based_exchange(exchange["id"])(coins, final_contracts)

--- a/api/ext/exchanges/rates_manager.py
+++ b/api/ext/exchanges/rates_manager.py
@@ -81,14 +81,11 @@ class RatesManager:
         for name, exchange_cls in self._exchange_classes.items():
             self.exchanges[name] = exchange_cls(coins, final_contracts)
         try:
-            if settings.settings.coingecko_apikey:
-                coingecko_exchanges = await utils.common.send_request(
-                    "GET",
-                    "https://pro-api.coingecko.com/api/v3/exchanges/list",
-                    headers={"x-cg-pro-api-key": settings.settings.coingecko_apikey},
-                )
-            else:
-                coingecko_exchanges = await utils.common.send_request("GET", "https://api.coingecko.com/api/v3/exchanges/list")
+            coingecko_exchanges = await utils.common.send_request(
+                "GET",
+                f"{settings.settings.coingecko_api_url}/exchanges/list",
+                headers=settings.settings.coingecko_headers,
+            )
             for exchange in coingecko_exchanges:
                 if exchange["id"] not in self.exchanges:
                     self.exchanges[exchange["id"]] = coingecko_based_exchange(exchange["id"])(coins, final_contracts)

--- a/api/settings.py
+++ b/api/settings.py
@@ -154,6 +154,18 @@ class Settings(BaseSettings):
         rootpath = "" if self.root_path == "/" else self.root_path
         return f"{self.protocol}://{self.api_host}{rootpath}"
 
+    @property
+    def coingecko_api_url(self):
+        if self.coingecko_apikey:
+            return "https://pro-api.coingecko.com/api/v3"
+        return "https://api.coingecko.com/api/v3"
+
+    @property
+    def coingecko_headers(self):
+        if self.coingecko_apikey:
+            return {"x-cg-pro-api-key": self.coingecko_apikey}
+        return {}
+
     @field_validator("enabled_cryptos", mode="before")
     @classmethod
     def validate_enabled_cryptos(cls, v):

--- a/api/settings.py
+++ b/api/settings.py
@@ -85,6 +85,7 @@ class Settings(BaseSettings):
     plugins_schema: dict = {}
     is_worker: bool = False
     sentry_dsn: str | None = Field(None, validation_alias="SENTRY_DSN")
+    coingecko_apikey: str | None = Field(None, validation_alias="COINGECKO_APIKEY")
 
     license_server_url: str = Field("https://licensing.bitcart.ai", validation_alias="LICENSE_SERVER_URL")
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -85,7 +85,7 @@ class Settings(BaseSettings):
     plugins_schema: dict = {}
     is_worker: bool = False
     sentry_dsn: str | None = Field(None, validation_alias="SENTRY_DSN")
-    coingecko_apikey: str | None = Field(None, validation_alias="COINGECKO_APIKEY")
+    coingecko_api_key: str | None = Field(None, validation_alias="COINGECKO_API_KEY")
 
     license_server_url: str = Field("https://licensing.bitcart.ai", validation_alias="LICENSE_SERVER_URL")
 
@@ -156,14 +156,14 @@ class Settings(BaseSettings):
 
     @property
     def coingecko_api_url(self):
-        if self.coingecko_apikey:
+        if self.coingecko_api_key:
             return "https://pro-api.coingecko.com/api/v3"
         return "https://api.coingecko.com/api/v3"
 
     @property
     def coingecko_headers(self):
-        if self.coingecko_apikey:
-            return {"x-cg-pro-api-key": self.coingecko_apikey}
+        if self.coingecko_api_key:
+            return {"x-cg-pro-api-key": self.coingecko_api_key}
         return {}
 
     @field_validator("enabled_cryptos", mode="before")


### PR DESCRIPTION
On this PR I'm bringing support to use the pro API that Coingecko offers.

Free API could be enough, but in case that you have access or want to use the paid version, you can now provide an API Key with `COINGECKO_APIKEY` env variable.

Coingecko paid API offers a higher stability which can be beneficial if you can afford it.