### PR TITLE
Electrum additions

### DIFF
--- a/api/plugins.py
+++ b/api/plugins.py
@@ -229,7 +229,7 @@ class BaseCoin(metaclass=ABCMeta):
     async def open_channel(self, *args: Any, **kwargs: Any) -> bool:
         return False
     
-    async def list_ln_peers(self, *args: Any, **kwargs: Any) -> bool:
+    async def list_ln_peers(self, *args: Any, **kwargs: Any) -> List[str]:
         return []
     
     async def add_peer(self, *args: Any, **kwargs: Any) -> bool:

--- a/api/plugins.py
+++ b/api/plugins.py
@@ -228,6 +228,12 @@ class BaseCoin(metaclass=ABCMeta):
 
     async def open_channel(self, *args: Any, **kwargs: Any) -> bool:
         return False
+    
+    async def list_ln_peers(self, *args: Any, **kwargs: Any) -> bool:
+        return []
+    
+    async def add_peer(self, *args: Any, **kwargs: Any) -> bool:
+        return False
 
     async def close_channel(self, *args: Any, **kwargs: Any) -> bool:
         return False


### PR DESCRIPTION
Add functions to API to talk w Electrum and:

- Get list of lightning peers
- Add peers to list

Reason for these additions:
- Enables working w electrum more directly without exposing Electrum JSON-RPC port. Enables plugins to access these commands without seperate connection to wallet
- Liquidity providers (Zeus, Megalithic, etc) require a node to have a peer connection to them first before requesting liquidity. Previously this was only possible if a channel was open to them, which costs money and time.

I differentiated between "peer" and "ln_peer" since you can have different peers on main chain and lightning. Electrum wallet itself does not clearly differentiate between them in the JSON-RPC API.