### PR TITLE
Check debug capabilities against current block

### DIFF
--- a/daemons/eth.py
+++ b/daemons/eth.py
@@ -413,7 +413,7 @@ class ETHDaemon(BlockProcessorDaemon):
         self.trace_queue = asyncio.Queue()
         await self.create_coin(archive=True)
         with contextlib.suppress(Exception):
-            height = await self.get_block_number()
+            height = await self.archive_coin.get_block_number()
             await self.archive_coin.debug_trace_block(height)
             self.trace_available = True
         await super().on_startup(app)

--- a/daemons/eth.py
+++ b/daemons/eth.py
@@ -413,7 +413,8 @@ class ETHDaemon(BlockProcessorDaemon):
         self.trace_queue = asyncio.Queue()
         await self.create_coin(archive=True)
         with contextlib.suppress(Exception):
-            await self.archive_coin.debug_trace_block(1)
+            height = await self.get_block_number()
+            await self.archive_coin.debug_trace_block(height)
             self.trace_available = True
         await super().on_startup(app)
         if self.trace_available:


### PR DESCRIPTION
This PR brings the option to use the daemon against a Geth > 1.16 partial archive node.

I was running a partial archive node using Geth 1.15 and the daemon was compatible with it (don't know if because I configured it initially as a full archive and then changed to full and then back to archive, was configured time ago...). Geth introduced huge optimizations for Archive nodes in 1.16, so I ran a full archive node to ensure that the deprecations in their side do not affect the daemon, everything was working nice.

But, if you try to run a partial archive node (basically dropping after a number of states), it will break the functionality of the daemon as we are checking `debug` capabilities against the block `1` which obviosly will not be in a partial archive node. In my opinion, checking this against the current block, will gives us the same functionality without requiring a full archive.

I tested it and works as expected.