### PR TITLE
fix: skip user filtering on endpoints with optional auth

### DIFF
--- a/api/utils/routing.py
+++ b/api/utils/routing.py
@@ -168,9 +168,16 @@ def create_crud_router(
     enabled_endpoints = dict.fromkeys(ALL_ENDPOINTS, True)
     if disabled_endpoints is not None:
         enabled_endpoints = {k: v and not disabled_endpoints.get(k, False) for k, v in enabled_endpoints.items()}
+
+    async def _no_user() -> models.User | None:
+        # Used for endpoints where auth_config is False: always resolve user to None so
+        # CRUDService._add_user_filter does not scope queries to the caller, even if a
+        # valid token happens to be sent with the request.
+        return None
+
     auth_deps = {
         endpoint: Security(
-            utils.authorization.auth_dependency if auth_config[endpoint] else utils.authorization.optional_auth_dependency,
+            utils.authorization.auth_dependency if auth_config[endpoint] else _no_user,
             scopes=required_scopes,
         )
         for endpoint in ALL_ENDPOINTS

--- a/tests/test_views/test_views.py
+++ b/tests/test_views/test_views.py
@@ -2087,3 +2087,15 @@ async def test_mark_complete_validation(client: TestClient, token: str, store: d
     )
     assert resp.status_code == 422
     assert "Payment method does-not-exist not found" in resp.json()["detail"]
+
+
+async def test_get_invoice_of_another_user(client: TestClient, token: str, limited_user: dict[str, Any]) -> None:
+    # Create an invoice as the main (super) user
+    invoice = await create_invoice(client, token)
+    invoice_id = invoice["id"]
+    # Create a token for the limited user
+    limited_token = (await create_token(client, limited_user))["access_token"]
+    # Fetch the invoice as the limited user - should succeed (not 404)
+    resp = await client.get(f"/invoices/{invoice_id}", headers={"Authorization": f"Bearer {limited_token}"})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == invoice_id


### PR DESCRIPTION
## Summary
When `auth_config` marks an endpoint as optional (`False`), authenticated requests no longer scope queries to the current user. This fixes the 404 when a logged-in user tries to view another user's invoice.

Fixes #535

## Root Cause
`optional_auth_dependency` still resolves a valid token into a `User` object. `_add_user_filter` in `CRUDService` then adds `WHERE user_id = <current_user_id>`, filtering out invoices owned by other users and returning 404.

## Design Decision
The fix lives in `create_crud_router` (routing layer) rather than in `InvoiceService` because that's where `auth_config` is defined and where the intent "this endpoint doesn't require auth" is expressed. By forcing `user = None` when `auth_config[endpoint]` is `False`, the fix is generic — any future view that uses optional auth will automatically get the correct behavior. The alternative of overriding `_add_user_filter` per-service would be more targeted but would need to be repeated for each view.

## What Changed
- `api/utils/routing.py`: For each CRUD endpoint (`list`, `count`, `get`, `create`), when `auth_config[endpoint]` is `False`, force `user = None` before passing to the service layer
- `tests/test_views/test_views.py`: Added `test_get_invoice_of_another_user` — creates an invoice as User A, authenticates as User B, asserts GET returns 200 (not 404)

## Test Results
- All non-daemon tests pass (24 passed, no regressions)
- Invoice-specific test requires a running BTC daemon which I don't have locally — relying on CI for validation

---

Happy to adjust the approach if you'd prefer a different direction!