### PR TITLE
Expand Kraken exchange rate pairs

### DIFF
--- a/api/ext/exchanges/base.py
+++ b/api/ext/exchanges/base.py
@@ -23,7 +23,7 @@ EXCHANGE_ACTIVE_TIME = 12 * 60 * 60
 
 
 def get_inverse_dict(d: dict[str, Decimal]) -> dict[str, Decimal]:
-    return {str(ExchangePair(k).inverse()): 1 / v for k, v in d.items()}
+    return {str(ExchangePair(k).inverse()): 1 / v for k, v in d.items() if v != 0}
 
 
 class BaseExchange(metaclass=ABCMeta):

--- a/api/ext/exchanges/kraken.py
+++ b/api/ext/exchanges/kraken.py
@@ -1,10 +1,57 @@
+from decimal import Decimal
+from typing import Any
+
 from api import utils
 from api.ext.exchanges.base import BaseExchange
+
+KRAKEN_API_URL = "https://api.kraken.com/0/public"
+KRAKEN_ASSET_PAIRS_URL = f"{KRAKEN_API_URL}/AssetPairs"
+KRAKEN_TICKER_URL = f"{KRAKEN_API_URL}/Ticker"
+KRAKEN_ASSET_ALIASES = {"XBT": "BTC"}
+KRAKEN_ONLINE_STATUS = "online"
+
+
+def normalize_kraken_asset(asset: str) -> str:
+    return KRAKEN_ASSET_ALIASES.get(asset, asset).upper()
+
+
+def normalize_kraken_pair(pair: dict[str, Any]) -> str | None:
+    wsname = pair.get("wsname")
+    if not isinstance(wsname, str) or "/" not in wsname:
+        return None
+    base, quote = wsname.split("/", maxsplit=1)
+    return f"{normalize_kraken_asset(base)}_{normalize_kraken_asset(quote)}"
+
+
+def get_kraken_result(response: dict[str, Any], endpoint: str) -> dict[str, Any]:
+    errors = response.get("error") or []
+    if errors:
+        raise ValueError(f"Kraken {endpoint} request failed: {', '.join(errors)}")
+    return response["result"]
+
+
+def get_online_kraken_pairs(asset_pairs: dict[str, Any]) -> dict[str, str]:
+    return {
+        pair_id: normalized_pair
+        for pair_id, pair in asset_pairs.items()
+        if pair.get("status") == KRAKEN_ONLINE_STATUS
+        if (normalized_pair := normalize_kraken_pair(pair)) is not None
+    }
+
+
+def build_kraken_quotes(asset_pairs: dict[str, Any], ticker: dict[str, Any]) -> dict[str, Decimal]:
+    pairs = get_online_kraken_pairs(asset_pairs)
+    return {
+        pairs[pair_id]: utils.common.precise_decimal(str(ticker_data["c"][0]))
+        for pair_id, ticker_data in ticker.items()
+        if pair_id in pairs and ticker_data.get("c")
+    }
 
 
 class Kraken(BaseExchange):
     async def refresh(self) -> None:
-        ccys = ["EUR", "USD", "CAD", "GBP", "JPY"]
-        pairs = [f"XBT{c}" for c in ccys]
-        json = await utils.common.send_request("GET", "https://api.kraken.com/0/public/Ticker?pair={}".format(",".join(pairs)))
-        self.quotes = {f"BTC_{k[-3:]}": utils.common.precise_decimal(str(v["c"][0])) for k, v in json["result"].items()}
+        asset_pairs_response = await utils.common.send_request("GET", KRAKEN_ASSET_PAIRS_URL)
+        ticker_response = await utils.common.send_request("GET", KRAKEN_TICKER_URL)
+        asset_pairs = get_kraken_result(asset_pairs_response, "AssetPairs")
+        ticker = get_kraken_result(ticker_response, "Ticker")
+        self.quotes = build_kraken_quotes(asset_pairs, ticker)

--- a/api/ext/exchanges/kraken.py
+++ b/api/ext/exchanges/kraken.py
@@ -19,6 +19,8 @@ def normalize_kraken_pair(pair: dict[str, Any]) -> str | None:
     wsname = pair.get("wsname")
     if not isinstance(wsname, str) or "/" not in wsname:
         return None
+    if wsname.endswith(":BTNL"):
+        return None  # skip synthetic markets
     base, quote = wsname.split("/", maxsplit=1)
     return f"{normalize_kraken_asset(base)}_{normalize_kraken_asset(quote)}"
 

--- a/tests/test_exchanges/test_kraken.py
+++ b/tests/test_exchanges/test_kraken.py
@@ -5,7 +5,13 @@ from unittest.mock import Mock
 import pytest
 import pytest_mock
 
-from api.ext.exchanges.kraken import KRAKEN_ASSET_PAIRS_URL, KRAKEN_TICKER_URL, Kraken
+from api.ext.exchanges.kraken import (
+    KRAKEN_ASSET_PAIRS_URL,
+    KRAKEN_TICKER_URL,
+    Kraken,
+    get_kraken_result,
+    normalize_kraken_pair,
+)
 
 ONLINE_ASSET_PAIRS = {
     "XXBTZUSD": {"wsname": "XBT/USD", "status": "online"},
@@ -69,3 +75,42 @@ async def test_kraken_get_rate_adds_inverse_pairs(mocker: pytest_mock.MockerFixt
     exchange = kraken_exchange()
 
     assert await exchange.get_rate("EUR_ETH") == Decimal("0.0005")
+
+
+@pytest.mark.parametrize(
+    "pair",
+    [
+        {},
+        {"wsname": None},
+        {"wsname": ""},
+        {"wsname": "XBTUSD"},
+    ],
+)
+def test_normalize_kraken_pair_rejects_invalid_wsname(pair: dict[str, Any]) -> None:
+    assert normalize_kraken_pair(pair) is None
+
+
+def test_normalize_kraken_pair_skips_synthetic_markets() -> None:
+    assert normalize_kraken_pair({"wsname": "XBT/USD:BTNL"}) is None
+
+
+def test_get_kraken_result_raises_on_error() -> None:
+    response = {"error": ["EAPI:Rate limit", "EService:Unavailable"], "result": {}}
+
+    with pytest.raises(ValueError, match="Kraken Ticker request failed: EAPI:Rate limit, EService:Unavailable"):
+        get_kraken_result(response, "Ticker")
+
+
+@pytest.mark.anyio
+async def test_kraken_refresh_raises_on_kraken_error(mocker: pytest_mock.MockerFixture) -> None:
+    mocker.patch(
+        "api.ext.exchanges.kraken.utils.common.send_request",
+        side_effect=[
+            {"error": ["EGeneral:Invalid arguments"], "result": {}},
+            kraken_response({}),
+        ],
+    )
+    exchange = kraken_exchange()
+
+    with pytest.raises(ValueError, match="Kraken AssetPairs request failed: EGeneral:Invalid arguments"):
+        await exchange.refresh()

--- a/tests/test_kraken_exchange.py
+++ b/tests/test_kraken_exchange.py
@@ -1,0 +1,71 @@
+from decimal import Decimal
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+import pytest_mock
+
+from api.ext.exchanges.kraken import KRAKEN_ASSET_PAIRS_URL, KRAKEN_TICKER_URL, Kraken
+
+ONLINE_ASSET_PAIRS = {
+    "XXBTZUSD": {"wsname": "XBT/USD", "status": "online"},
+    "XETHZEUR": {"wsname": "ETH/EUR", "status": "online"},
+    "DOTUSD": {"wsname": "DOT/USD", "status": "online"},
+}
+
+TICKER_PRICES = {
+    "XXBTZUSD": {"c": ["100.1"]},
+    "XETHZEUR": {"c": ["200.2"]},
+    "DOTUSD": {"c": ["3.3"]},
+}
+
+
+def kraken_response(result: dict[str, Any]) -> dict[str, Any]:
+    return {"error": [], "result": result}
+
+
+def kraken_exchange() -> Kraken:
+    return Kraken(None, None, [], {})  # type: ignore[arg-type]
+
+
+def mock_kraken_requests(
+    mocker: pytest_mock.MockerFixture, asset_pairs: dict[str, Any], ticker_prices: dict[str, Any]
+) -> Mock:
+    return mocker.patch(
+        "api.ext.exchanges.kraken.utils.common.send_request",
+        side_effect=[kraken_response(asset_pairs), kraken_response(ticker_prices)],
+    )
+
+
+@pytest.mark.anyio
+async def test_kraken_refresh_loads_all_online_pairs(mocker: pytest_mock.MockerFixture) -> None:
+    send_request = mock_kraken_requests(
+        mocker,
+        asset_pairs={**ONLINE_ASSET_PAIRS, "XXBTZJPY": {"wsname": "XBT/JPY", "status": "cancel_only"}},
+        ticker_prices={**TICKER_PRICES, "XXBTZJPY": {"c": ["400.4"]}},
+    )
+    exchange = kraken_exchange()
+
+    await exchange.refresh()
+
+    assert exchange.quotes == {
+        "BTC_USD": Decimal("100.1"),
+        "ETH_EUR": Decimal("200.2"),
+        "DOT_USD": Decimal("3.3"),
+    }
+    assert send_request.call_args_list == [
+        mocker.call("GET", KRAKEN_ASSET_PAIRS_URL),
+        mocker.call("GET", KRAKEN_TICKER_URL),
+    ]
+
+
+@pytest.mark.anyio
+async def test_kraken_get_rate_adds_inverse_pairs(mocker: pytest_mock.MockerFixture) -> None:
+    mock_kraken_requests(
+        mocker,
+        asset_pairs={"XETHZEUR": ONLINE_ASSET_PAIRS["XETHZEUR"]},
+        ticker_prices={"XETHZEUR": {"c": ["2000"]}},
+    )
+    exchange = kraken_exchange()
+
+    assert await exchange.get_rate("EUR_ETH") == Decimal("0.0005")


### PR DESCRIPTION
## Summary
- expand Kraken exchange rates from hardcoded BTC/fiat pairs to all online Kraken spot pairs
- normalize Kraken `XBT` symbols to Bitcart `BTC` pairs
- add focused tests for non-BTC Kraken pairs and inverse pair generation

## Why
Kraken was already available as a non-Coingecko exchange source, but it only exposed a small set of BTC fiat pairs. This handles the Kraken-specific part of #552 and makes the provider useful for more currencies without adding another external dependency.

Refs #552.

## Test Plan
- `uv run --no-dev --group web --group test --group otel pytest tests\test_kraken_exchange.py -q --noconftest -o addopts=`
- `uv run --no-dev --group lint ruff check api\ext\exchanges\kraken.py tests\test_kraken_exchange.py`
- `uv run --no-dev --group lint ruff format --check api\ext\exchanges\kraken.py tests\test_kraken_exchange.py`
- `git -c core.autocrlf=false diff --check`
