### PR TITLE
fix(genericprocessor): disambiguate same-amount pending requests on shared addresses

### DIFF
--- a/daemons/genericprocessor.py
+++ b/daemons/genericprocessor.py
@@ -389,7 +389,46 @@ class Wallet:
             raise Exception("Out of bounds amount")
         timestamp = int(time.time())
         expiration = expiration or 0
+        # Account-model chains (ETH, TRX, XMR…) share a single receive address
+        # per wallet, so two pending requests with identical amounts cannot be
+        # told apart when an onchain payment lands. Bump the amount by the
+        # smallest representable unit per collision so the onchain matcher
+        # can disambiguate. Stablecoins on these chains (USDT-TRC20, USDC-ERC20)
+        # are the common case — pegged to USD they produce identical token
+        # amounts for identical USD invoices.
+        amount = self._disambiguate_pending_amount(address, amount)
         return await self.create_payment_request_object(address, amount, message, expiration, timestamp)
+
+    def _disambiguate_pending_amount(self, address, amount):
+        """Return ``amount`` bumped by ``10**-divisibility`` per existing
+        same-address same-amount pending request, so each pending request
+        has a unique on-chain amount target.
+
+        Capped at 99 iterations as a defensive guard — in normal operation
+        collisions are rare and 99 simultaneous identical-amount requests
+        would already indicate abuse or misconfiguration.
+        """
+        if amount <= Decimal(0):
+            return amount
+        min_unit = Decimal(1) / (Decimal(10) ** self.divisibility)
+        bumped = amount
+        for _ in range(99):
+            if not self._has_pending_request_with_amount(address, bumped):
+                return bumped
+            bumped += min_unit
+        # Pool exhausted; fall back to the original amount and let the
+        # caller observe the collision (preserves previous behaviour).
+        return amount
+
+    def _has_pending_request_with_amount(self, address, amount):
+        for req in self.receive_requests.values():
+            if (
+                getattr(req, "address", None) == address
+                and getattr(req, "amount", None) == amount
+                and getattr(req, "status", None) == PR_UNPAID
+            ):
+                return True
+        return False
 
     async def create_payment_request_object(self, address, amount, message, expiration, timestamp):
         return Invoice(


### PR DESCRIPTION
## Summary

Fixes #605 — account-model chains (ETH, TRX, XMR) share a single receive address per wallet. Two pending requests with identical amounts produce identical on-chain targets and the matcher can't tell them apart when a payment lands. Stablecoin merchants are the common victim (USDT-TRC20 invoices for the same USD price are token-identical on a shared address).

## Fix

In \`daemons/genericprocessor.py\`, \`Wallet.make_payment_request\` now calls a new helper \`_disambiguate_pending_amount\` that bumps the new request's amount by \`10^-divisibility\` per existing same-amount same-address pending request. Each pending request thus has a unique on-chain target.

Capped at 99 iterations as a defensive guard — collisions are rare and >99 simultaneous identical-amount requests would itself signal abuse.

## What's NOT touched

- **BTC and other UTXO chains**: separate code path in \`daemons/btc.py\` with HD-derived per-invoice addresses. No collision possible.
- **Existing single-request flow**: when the amount has no pending collisions (the common case), \`_disambiguate_pending_amount\` returns the input unchanged. Zero behavioural change for sequential / non-overlapping requests.
- **The matcher** (\`process_transaction\` and related): no changes. It already keys on \`(address, amount, status=PR_UNPAID)\` — once amounts are unique, matching is deterministic.

## Repro for reviewers

\`\`\`bash
# Two pending TRC20 requests for the same amount, same wallet:
curl -X POST http://daemon:5009 \
  -H 'Content-Type: application/json' \
  -d '{\"method\": \"add_request\", \"params\": [30.0, \"A\", 3600], \"xpub\": \"<addr>\"}'
curl -X POST http://daemon:5009 \
  -H 'Content-Type: application/json' \
  -d '{\"method\": \"add_request\", \"params\": [30.0, \"B\", 3600], \"xpub\": \"<addr>\"}'

# Before this PR:  both requests = 30.000000 USDT to <addr>
# After this PR:   first request = 30.000000, second = 30.000001 USDT to <addr>
\`\`\`

## Test coverage

The existing \`tests/functional/test_functional.py\` uses \`regtest_wallet.add_request(fund_amount)\` with sequential single calls — those continue to pass unchanged (the helper returns the input when no collision exists).

A unit test for \`_has_pending_request_with_amount\` and \`_disambiguate_pending_amount\` can be added if reviewers want; happy to push a follow-up commit. The logic is small and isolated so I kept the diff minimal here for review.

## Real-world context

Found while building production checkout. Two \$30 USDT-TRC20 invoices generated in parallel to the same TRON address ended up with token amounts that Bitcart could not disambiguate when payment arrived. Built an edge-side workaround locally ("1 pending TRC20 invoice per user") as immediate mitigation, but the root cause lives upstream and benefits every merchant on account-model stablecoins.